### PR TITLE
remove "KenIngle.com" from default site title

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <title>{% block title %}{% endblock %} KenIngle.com</title>
+    <title>{% block title %}{% endblock %}{{ SITENAME }}</title>
 
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/{{ CSS_FILE }}">
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/pygment_trac.css">


### PR DESCRIPTION
every site created with this template has "KenIngle.com" in the title - change to {{ SITENAME }}
