### PR TITLE
Support for Google Plus' new custom urls and insertion of Google Analytics code in base template.

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -161,6 +161,7 @@ div[class='social'] a {
 .social a[href*='git.io'] {background-image: url('../images/icons/github.png');}
 .social a[href*='gittip.com'] {background-image: url('../images/icons/gittip.png');}
 .social a[href*='plus.google.com'] {background-image: url('../images/icons/google-plus.png');}
+.social a[href*='google.com/\+'] {background-image: url('../images/icons/google-plus.png');}
 .social a[href*='groups.google.com'] {background-image: url('../images/icons/google-groups.png');}
 .social a[href*='news.ycombinator.com'],
 .social a[href*='hackernewsers.com'] {background-image: url('../images/icons/hackernews.png');}

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,5 +54,6 @@
         }
       }
     </script>
+    {% include 'analytics.html' %}
   </body>
 </html>


### PR DESCRIPTION
- I'm not sure how new it is but google now allows custom urls for it's plus service. The commit allows for the displaying of the google plus icon for those urls too.
- The google analytics code wasn't being included in the base template. The commit includes it so that it's available on all pages.

Thanks,
Dave
