### PR TITLE
changed 'PAGES' to 'pages' in sidebar.html

### DIFF
--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -1,6 +1,6 @@
 {% if DISPLAY_PAGES_ON_MENU -%}
 <p>
-  {% for page in PAGES %}
+  {% for page in pages %}
     <div class="view"><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></div>
   {% endfor %}
   <div class="view"><a href="{{ SITEURL }}/archives.html">Archives</a></div>


### PR DESCRIPTION
Thanks for this theme, it's great and I plan to use it for a personal site. 

The current version doesn't quite work because the sidebar.html template still used 'PAGES? instead of 'pages'. I have amended that and it works for me now. 

The issue is described here...

https://github.com/getpelican/pelican/issues/2097